### PR TITLE
Add getCardSize to card-loader

### DIFF
--- a/card-loader.js
+++ b/card-loader.js
@@ -38,6 +38,10 @@ class CardLoader extends cardTools.litElement() {
     this._hass = hass;
     if(this.card) this.card.hass = hass;
   }
+  
+  getCardSize() {
+    return typeof this.card.getCardSize === 'function' ? this.card.getCardSize() : 1
+  }
 }
 
 customElements.define('card-loader', CardLoader);


### PR DESCRIPTION
This will fix an issue which happens when you embed card-loader inside a lovelace-state-switch card.